### PR TITLE
Updating QuoteBlock

### DIFF
--- a/project_name/utils/blocks.py
+++ b/project_name/utils/blocks.py
@@ -85,7 +85,7 @@ class LinkStreamBlock(blocks.StreamBlock):
 
 
 class QuoteBlock(blocks.StructBlock):
-    quote = blocks.CharBlock(form_classname="title")
+    quote = blocks.TextBlock(form_classname="title")
     attribution = blocks.CharBlock(required=False)
 
     class Meta:

--- a/project_name/utils/blocks.py
+++ b/project_name/utils/blocks.py
@@ -87,7 +87,6 @@ class LinkStreamBlock(blocks.StreamBlock):
 class QuoteBlock(blocks.StructBlock):
     quote = blocks.CharBlock(form_classname="title")
     attribution = blocks.CharBlock(required=False)
-    link = LinkStreamBlock(required=False, min_num=0)
 
     class Meta:
         icon = "openquote"

--- a/templates/components/streamfield/blocks/quote_block.html
+++ b/templates/components/streamfield/blocks/quote_block.html
@@ -1,5 +1,12 @@
 {% verbatim %}
-<div class="">
-    {{ self }}
+<div class="mb-10 md:mb-20 last:mb-0">
+    <p class="font-serif4 text-3xl md:text-5xl font-semibold text-center mb-8 md:mb-10">
+        "{{ value.quote }}"
+    </p>
+    {% if value.attribution %}
+        <p class="font-serif4 text-base md:text-xl font-medium text-center mb-8 md:mb-10">
+            - {{ value.attribution }}
+        </p>
+    {% endif %}
 </div>
 {% endverbatim %}


### PR DESCRIPTION
This PR addresses the QuoteBlock component of #38

I have removed the link from QuoteBlock because adding links to quote blocks is not a common feature for most publications and leaving it in would be confusing to most folks familiar with online publishing.

I have added in a basic HTML template but will leave this as a draft to give me some time to figure out our Tailwind classes and determine if there is better basic design option for this block.