### PR TITLE
Updating ImageBlock template

### DIFF
--- a/templates/components/streamfield/blocks/image_block.html
+++ b/templates/components/streamfield/blocks/image_block.html
@@ -2,8 +2,8 @@
 {% load wagtailimages_tags %}
 
 <div class="pb-10 md:pb-20 flex justify-center">
-    <div class="mx-auto">
-        {% image value.image width-640 class="mx-auto" %}
+    <div>
+        {% image value.image width-640 %}
         {% if value.caption %}
             <p class="text-xs text-strong mt-4">{{ value.caption }}</p>
         {% endif %}

--- a/templates/components/streamfield/blocks/image_block.html
+++ b/templates/components/streamfield/blocks/image_block.html
@@ -1,5 +1,12 @@
 {% verbatim %}
-<div class="">
-    {{ self }}
+{% load wagtailimages_tags %}
+
+<div class="pb-10 md:pb-20 flex justify-center">
+    <div class="mx-auto">
+        {% image value.image width-640 class="mx-auto" %}
+        {% if value.caption %}
+            <p class="text-xs text-strong mt-4">{{ value.caption }}</p>
+        {% endif %}
+    </div>
 </div>
 {% endverbatim %}

--- a/templates/components/streamfield/blocks/image_block.html
+++ b/templates/components/streamfield/blocks/image_block.html
@@ -5,7 +5,7 @@
     <div>
         {% image value.image width-640 %}
         {% if value.caption %}
-            <p class="text-xs text-strong mt-4">{{ value.caption }}</p>
+            <p class="mt-4">{{ value.caption }}</p>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
This PR addresses #38 

In this PR, I offered a functional template for `ImageBlock()`. I chose to use the `image` tag rather than the `picture` tag because I felt it would be best to show the simplest option. I'm open to using `picture` instead if there is a preference for demonstrating that method as a best practice.