### PR TITLE
Removing OptionalLinkStreamBlock

### DIFF
--- a/project_name/utils/blocks.py
+++ b/project_name/utils/blocks.py
@@ -88,14 +88,6 @@ class LinkStreamBlock(blocks.StreamBlock):
         max_num = 1
 
 
-class OptionalLinkStreamBlock(LinkStreamBlock):
-    class Meta:
-        icon = "link"
-        label = "Link"
-        min_num = 0
-        max_num = 1
-
-
 class QuoteBlock(blocks.StructBlock):
     quote = blocks.CharBlock(form_classname="title")
     attribution = blocks.CharBlock(required=False)


### PR DESCRIPTION
As far as I can tell `OptionalLinkStreamBlock` is not really necessary. Using `LinkStreamBlock(required=False, min_num=0)` seems to achieve the same result.

As a result, I suggest we remove this block rather than keep it in the code.