### PR TITLE
Refactoring BaseInternaLinkBlock

### DIFF
--- a/project_name/utils/blocks.py
+++ b/project_name/utils/blocks.py
@@ -42,7 +42,7 @@ class ImageBlock(blocks.StructBlock):
         template = "components/streamfield/blocks/image_block.html"
 
 
-class BaseInternalLinkBlock(blocks.StructBlock):
+class InternalLinkBlock(blocks.StructBlock):
     page = blocks.PageChooserBlock()
     title = blocks.CharBlock(
         required=False,
@@ -55,10 +55,10 @@ class BaseInternalLinkBlock(blocks.StructBlock):
         value_class = LinkStructValue
 
 
-class InternalLinkBlock(BaseInternalLinkBlock):
+class InternalLinkBlock(InternalLinkBlock):
     pass
 
-class ArticlePageLinkBlock(BaseInternalLinkBlock):
+class ArticlePageLinkBlock(InternalLinkBlock):
     page = blocks.PageChooserBlock(
         page_type="news.ArticlePage",
     )

--- a/project_name/utils/blocks.py
+++ b/project_name/utils/blocks.py
@@ -54,10 +54,6 @@ class InternalLinkBlock(blocks.StructBlock):
         icon = "link"
         value_class = LinkStructValue
 
-
-class InternalLinkBlock(InternalLinkBlock):
-    pass
-
 class ArticlePageLinkBlock(InternalLinkBlock):
     page = blocks.PageChooserBlock(
         page_type="news.ArticlePage",

--- a/project_name/utils/blocks.py
+++ b/project_name/utils/blocks.py
@@ -50,9 +50,9 @@ class InternalLinkBlock(blocks.StructBlock):
     )
 
     class Meta:
-        abstract = True
         icon = "link"
         value_class = LinkStructValue
+
 
 class ArticlePageLinkBlock(InternalLinkBlock):
     page = blocks.PageChooserBlock(


### PR DESCRIPTION
If there is a good reason to have both a `BaseInternalLinkBlock` and `InternalLinkBlock`, I am all ears. But it seems like this project as it currently stands doesn't really require the extra block for everything to function properly.

If there is a best practice reason for keeping both, then we should consider documenting it so people are aware of it and know what use cases having the separate blocks would be good for..