### PR TITLE
Fixed Featured section not appearing on blog pages

### DIFF
--- a/templates/pages/article_page.html
+++ b/templates/pages/article_page.html
@@ -69,5 +69,7 @@
 
 {% include_block page.body %}
 
+{% include "components/related-pages.html" %}
+
 {% endblock %}
 {% endverbatim %}


### PR DESCRIPTION
This PR provides a simple fix for #49.

It looks like the "Featured section" component was added to the Home page and the Standard page templates but not the Article page. I added a line to the Article page template that includes `related_pages.html` to make that feature accessible on blog pages as well.

I feel like this feature doesn't have the best intuitive design for editors and could use further revision. But this fix will at least make it functional for now, which is a higher priority.